### PR TITLE
Implement board password protection

### DIFF
--- a/routes/board_routes.py
+++ b/routes/board_routes.py
@@ -33,7 +33,7 @@ def is_team_authenticated(provided_pw: str, team_name: str) -> bool:
     try:
         team_entry = db_entities.Team(database.get_team_by_name(team_name)) 
 
-        return teampassword.calculate_team_password(team_entry) == provided_pw
+        return teampassword.calculate_team_password(team_entry.team_webhook) == provided_pw
     except:
         return False
 

--- a/templates/admin_templates/team_templates/team_list.html
+++ b/templates/admin_templates/team_templates/team_list.html
@@ -85,8 +85,8 @@
                 <td>{{ team[3] }}</td>
                 <td>{{ team[0] }}</td>
                 <td>{{ team[1] }}</td>
-                <td>{{ team[2] }}</td>
-                <td>{{ team[4] }}</td>
+                <td><a href="{{ team[2] }}">Webhook</a></td>
+                <td><a href="{{ team[4] }}">Link</a></td>
                 <td>
                     <div class="action-buttons">
                         <form action="{{ url_for('team_routes.edit_team', team_id=team[3]) }}" method="GET">

--- a/templates/admin_templates/team_templates/team_list.html
+++ b/templates/admin_templates/team_templates/team_list.html
@@ -75,6 +75,7 @@
                 <th>Name</th>
                 <th>Points</th>
                 <th>Webhook</th>
+                <th>Board Link</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -85,6 +86,7 @@
                 <td>{{ team[0] }}</td>
                 <td>{{ team[1] }}</td>
                 <td>{{ team[2] }}</td>
+                <td>{{ team[4] }}</td>
                 <td>
                     <div class="action-buttons">
                         <form action="{{ url_for('team_routes.edit_team', team_id=team[3]) }}" method="GET">

--- a/utils/teampassword.py
+++ b/utils/teampassword.py
@@ -1,0 +1,18 @@
+import hashlib
+
+def calculate_team_password(team_entry: object) -> str:
+    """Calculates the team password for a given team database entry
+
+    This is not super secure but obfuscates access to the team boards - it's just a portion of the SHA256 hash
+    of the team's webhook URL (which is private/not retrievable except with admin permissions)
+
+    Args:
+        team_entry (object): Team db entry
+
+    Returns:
+        str: Team password
+    """
+    hash = hashlib.sha256()
+    hash.update(team_entry.webhook_url.encode("utf-8"))
+    digest = hash.hexdigest()
+    return digest[:32]

--- a/utils/teampassword.py
+++ b/utils/teampassword.py
@@ -1,18 +1,18 @@
 import hashlib
 
-def calculate_team_password(team_entry: object) -> str:
+def calculate_team_password(webhook_url: str) -> str:
     """Calculates the team password for a given team database entry
 
     This is not super secure but obfuscates access to the team boards - it's just a portion of the SHA256 hash
     of the team's webhook URL (which is private/not retrievable except with admin permissions)
 
     Args:
-        team_entry (object): Team db entry
+        webhook_url (str): Team webhook url
 
     Returns:
         str: Team password
     """
     hash = hashlib.sha256()
-    hash.update(team_entry.webhook_url.encode("utf-8"))
+    hash.update(webhook_url.encode("utf-8"))
     digest = hash.hexdigest()
     return digest[:32]


### PR DESCRIPTION
Admins can copy a password-protected link for each team's board that allows team members to view their own board (but not other teams)